### PR TITLE
Extract stdlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ clickhouse-driver==0.1.1
 scipy==1.3.1
 jinja2==2.10.1
 pyyaml==5.1.2
+scrapy==1.7.3

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "scipy>=1.0,<2.0",
         "jinja2>=2.10.1<3.0",
         "pyyaml>=5.1.2<6",
+        "scrapy>=1.7.3<2.0",
     ],
     tests_require=["docker>=3.6.0,<4.0"],
     package_data={

--- a/sourced/ml/mining/__main__.py
+++ b/sourced/ml/mining/__main__.py
@@ -8,6 +8,7 @@ from sourced.ml.mining.cmd import (
     ArgumentDefaultsHelpFormatterNoNone,
     clickhouse2deps,
     CLICKHOUSE_LANGS,
+    collect_stdlibs,
 )
 
 
@@ -72,7 +73,26 @@ def parse_args() -> argparse.Namespace:
         choices=CLICKHOUSE_LANGS,
         help="Languages to consider while extracting dependencies.",
     )
+    # --------------------------------------------------------------------------------------------
 
+    collect_stdlibs_parser = add_parser(
+        "collect-stdlibs",
+        "Collect the lists of standard libraries for each language Babelfish can parse.",
+    )
+    collect_stdlibs_parser.set_defaults(handler=collect_stdlibs)
+    collect_stdlibs_parser.add_argument(
+        "-o",
+        "--output-path",
+        type=Path,
+        help="Output path to the resulting ASDF model with the extracted standard libraries.",
+    )
+    collect_stdlibs_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Boolean indicating whether to overwrite the existing ASDF model specified by "
+        "-o/--output-path.",
+    )
     args = parser.parse_args()
     if not hasattr(args, "handler"):
         args.handler = lambda _: parser.print_usage()  # noqa: E731

--- a/sourced/ml/mining/cmd/__init__.py
+++ b/sourced/ml/mining/cmd/__init__.py
@@ -1,3 +1,5 @@
 # flake8: noqa
 from sourced.ml.mining.cmd.args import ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.mining.cmd.clickhouse2deps import clickhouse2deps, CLICKHOUSE_LANGS
+from sourced.ml.mining.cmd.collect_stdlibs import collect_stdlibs
+

--- a/sourced/ml/mining/cmd/collect_stdlibs.py
+++ b/sourced/ml/mining/cmd/collect_stdlibs.py
@@ -1,0 +1,94 @@
+import argparse
+import logging
+
+from scrapy.crawler import CrawlerProcess
+
+from sourced.ml.mining.models import StandardLibraries
+from sourced.ml.mining.spiders import (
+    CppStdlibSpider,
+    CSharpStdlibSpider,
+    GoStdlibSpider,
+    JavaStdlibSpider,
+    PythonStdlibSpider,
+    RubyStdlibSpider,
+)
+from sourced.ml.mining.utils import check_remove_filepath, path_with_suffix
+
+
+class StdlibPipeline(object):
+    """Item pipeline that holds data in memory then saves it as a StandardLibraries model."""
+
+    library_names = {}
+    library_metadata = {}
+    pending_spiders = 0
+
+    def __init__(self, output_path):
+        """Create the item pipeline."""
+        self.output_path = output_path
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        """Pass the output path to the constructor when instantiating from the crawler."""
+        return cls(output_path=crawler.settings["OUTPUT_PATH"])
+
+    def open_spider(self, spider):
+        """Open a spider."""
+        type(self).pending_spiders += 1
+        log = logging.getLogger(spider.name)
+        log.info("Opened spider, pending: %d", self.pending_spiders)
+
+    def close_spider(self, spider):
+        """Close a spider, and save the model if it is the last to terminate."""
+        log = logging.getLogger(spider.name)
+        type(self).pending_spiders -= 1
+        log.info("Closed spider, pending: %d", self.pending_spiders)
+        if self.pending_spiders == 0:
+            log.info("No more spiders are running, creating the model ...")
+            StandardLibraries(log_level=logging.INFO).construct(
+                self.library_names, self.library_metadata
+            ).save(self.output_path, series="stdlib")
+            log.info("Saved model to %s", self.output_path)
+
+    def process_item(self, item, spider):
+        """Process an item returned by one of the spiders."""
+        lang, library_name = item["lang"], item["library_name"]
+        if lang not in self.library_names:
+            self.library_names[lang] = set()
+            self.library_metadata[lang] = {}
+        self.library_names[lang].add(library_name)
+        for meta in item["library_metadata"]:
+            if meta not in self.library_metadata[lang]:
+                self.library_metadata[lang][meta] = set()
+            self.library_metadata[lang][meta].add(library_name)
+
+
+def collect_stdlibs(args: argparse.Namespace):
+    """
+    Collect the lists of standard library_names for each language Babelfish can parse.
+    """
+    log = logging.getLogger("collect_stdlibs")
+    output_path = path_with_suffix(args.output_path, ".asdf")
+    check_remove_filepath(output_path, log, args.force)
+    process = CrawlerProcess(
+        settings={
+            "BOT_NAME": "vegeta",
+            "ITEM_PIPELINES": {
+                "sourced.ml.mining.cmd.collect_stdlibs.StdlibPipeline": 100
+            },
+            "LOG_ENABLED": 0,
+            "OUTPUT_PATH": output_path,
+        }
+    )
+    logging.getLogger("scrapy").setLevel(logging.WARNING)
+
+    for spider in [
+        CppStdlibSpider,
+        CSharpStdlibSpider,
+        GoStdlibSpider,
+        JavaStdlibSpider,
+        PythonStdlibSpider,
+        RubyStdlibSpider,
+    ]:
+        process.crawl(spider)
+    process.start()
+    process.stop()

--- a/sourced/ml/mining/models/__init__.py
+++ b/sourced/ml/mining/models/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa
 from sourced.ml.mining.models.dependencies import Dependencies
+from sourced.ml.mining.models.stdlib import StandardLibraries

--- a/sourced/ml/mining/models/stdlib.py
+++ b/sourced/ml/mining/models/stdlib.py
@@ -1,0 +1,67 @@
+from modelforge import merge_strings, Model, register_model, split_strings
+from sourced.ml.core.models.license import DEFAULT_LICENSE
+
+
+@register_model
+class StandardLibraries(Model):
+    """
+    List of standard library contents for each Babelfish language.
+    """
+
+    NAME = "stdlib"
+    VENDOR = "source{d}"
+    DESCRIPTION = (
+        "The list of standard library names for C++, C#, Go, Java, JavaSript, PHP, "
+        "Python and Ruby. The language versions and other metadata are stored when "
+        "found. The data is collected as exhaustively as possible."
+    )
+    LICENSE = DEFAULT_LICENSE
+
+    def construct(self, library_names, library_metadata):
+        self._library_names = library_names
+        self._library_metadata = library_metadata
+        self._langs = [l for l in sorted(library_names)]
+        return self
+
+    def _load_tree(self, tree):
+        library_names = {}
+        library_metadata = {lang: {} for lang in tree["langs"]}
+        for lang in tree["langs"]:
+            library_names[lang] = set(split_strings(tree[lang]["library_names"]))
+            for meta, libs in tree[lang]["library_metadata"].items():
+                library_metadata[lang][meta] = set(split_strings(libs))
+        self.construct(library_names, library_metadata)
+
+    def _generate_tree(self):
+        tree = {"langs": self._langs}
+        for lang, library_names in self._library_names.items():
+            tree[lang] = {"library_names": merge_strings(sorted(library_names))}
+            tree[lang]["library_metadata"] = {}
+            for meta, libs in self._library_metadata[lang].items():
+                tree[lang]["library_metadata"][meta] = merge_strings(sorted(libs))
+        return tree
+
+    def dump(self):
+        msg = []
+        for lang in self._langs:
+            msg.append("%s:" % lang)
+            msg.append("\t%d distinct library names" % len(self._library_names[lang]))
+            msg.append("\t%d distinct categories" % len(self._library_metadata[lang]))
+        return "\n".join(msg)
+
+    @property
+    def langs(self):
+        return self._langs
+
+    def get_library_names(self, lang):
+        return self._library_names.get(lang, [])
+
+    def get_library_metadata(self, lang):
+        return self._library_metadata.get(lang, {})
+
+    def get_library(self, lang, library):
+        return [
+            meta
+            for meta, libs in self.get_library_metadata(lang).items()
+            if library in libs
+        ]

--- a/sourced/ml/mining/spiders/__init__.py
+++ b/sourced/ml/mining/spiders/__init__.py
@@ -1,0 +1,7 @@
+# flake8: noqa
+from sourced.ml.mining.spiders.cpp_stdlib import CppStdlibSpider
+from sourced.ml.mining.spiders.csharp_stdlib import CSharpStdlibSpider
+from sourced.ml.mining.spiders.go_stdlib import GoStdlibSpider
+from sourced.ml.mining.spiders.java_stdlib import JavaStdlibSpider
+from sourced.ml.mining.spiders.python_stdlib import PythonStdlibSpider
+from sourced.ml.mining.spiders.ruby_stdlib import RubyStdlibSpider

--- a/sourced/ml/mining/spiders/cpp_stdlib.py
+++ b/sourced/ml/mining/spiders/cpp_stdlib.py
@@ -1,0 +1,43 @@
+import scrapy
+
+
+class CppStdlibSpider(scrapy.Spider):
+    """Spider for scraping the C/C++ standard libraries."""
+
+    name = "cpp-stdlib-spider"
+
+    def start_requests(self):
+        """Start making requests."""
+        url = "https://en.cppreference.com/w/%s/header"
+        for lang in ["c", "cpp"]:
+            request = scrapy.Request(url % lang, callback=self._parse)
+            request.meta["lang"] = lang
+            yield request
+
+    def _parse(self, response):
+        """Parse the response for the index."""
+        lang = response.meta["lang"]
+        if lang == "c":
+            default_since = "since C89/90"
+        else:
+            default_since = "since C++95"
+        for block in response.css("tr.t-dsc > td"):
+            library_name = block.css("b::text").get()
+            if library_name is None and lang == "cpp":
+                library_name = block.css("tt::text").get()
+            if not library_name:
+                continue
+            since = default_since
+            library_metadata = []
+            for i in block.css("span::text").getall():
+                i = i.strip("()")
+                if i.startswith("since"):
+                    since = i
+                else:
+                    library_metadata.append(i)
+            library_metadata.append(since)
+            yield {
+                "library_name": library_name.strip("<>"),
+                "lang": lang,
+                "library_metadata": library_metadata,
+            }

--- a/sourced/ml/mining/spiders/csharp_stdlib.py
+++ b/sourced/ml/mining/spiders/csharp_stdlib.py
@@ -1,0 +1,46 @@
+import json
+
+import scrapy
+
+
+class CSharpStdlibSpider(scrapy.Spider):
+    """Spider for scraping the C# standard libraries."""
+
+    name = "csharp-stdlib-spider"
+
+    def start_requests(self):
+        """Start making requests."""
+        url = "https://docs.microsoft.com/_api/familyTrees/byPlatform/dotnet"
+        yield scrapy.Request(url, callback=self._parse_index)
+
+    def _parse_index(self, response):
+        """Parse the response for the index."""
+        index = json.loads(response.text)
+        url = "https://docs.microsoft.com/api/apibrowser/dotnet/namespaces?moniker=%s"
+        for family in index:
+            family_name = family["familyName"]
+            for product in family["products"]:
+                product_name = product["productName"]
+                for package in product["packages"]:
+                    version = package["versionDisplayName"]
+                    moniker = package["monikerName"]
+                    request = scrapy.Request(url % moniker, callback=self._parse)
+                    request.meta["family"] = family_name
+                    request.meta["product"] = product_name
+                    request.meta["version"] = version
+                    yield request
+
+    def _parse(self, response):
+        """Parse the response for each package."""
+        content = json.loads(response.text)
+        library_metadata = [
+            response.meta["family"],
+            response.meta["product"],
+            response.meta["version"],
+        ]
+        for c in content["namespaces"]:
+            yield {
+                "library_name": c["displayName"],
+                "lang": "csharp",
+                "library_metadata": library_metadata,
+            }

--- a/sourced/ml/mining/spiders/go_stdlib.py
+++ b/sourced/ml/mining/spiders/go_stdlib.py
@@ -1,0 +1,27 @@
+import scrapy
+
+
+class GoStdlibSpider(scrapy.Spider):
+    """Spider for scraping the Go standard libraries."""
+
+    name = "go-stdlib-spider"
+
+    def start_requests(self):
+        """Start making requests."""
+        for url, kind in [
+            ("https://godoc.org/-/go", "core"),
+            ("https://godoc.org/-/subrepo", "subrepo"),
+        ]:
+            request = scrapy.Request(url, callback=self._parse)
+            request.meta["kind"] = kind
+            yield request
+
+    def _parse(self, response):
+        """Parse the response for the index."""
+        library_metadata = [response.meta["kind"]]
+        for library_name in response.css("td > a::attr(href)").getall():
+            yield {
+                "library_name": library_name.strip("/"),
+                "lang": "go",
+                "library_metadata": library_metadata,
+            }

--- a/sourced/ml/mining/spiders/java_stdlib.py
+++ b/sourced/ml/mining/spiders/java_stdlib.py
@@ -1,0 +1,53 @@
+from io import BytesIO
+import json
+from zipfile import ZipFile
+
+import scrapy
+
+
+class JavaStdlibSpider(scrapy.Spider):
+    """Spider for scraping the Java standard libraries."""
+
+    name = "java-stdlib-spider"
+
+    def start_requests(self):
+        """Start making requests."""
+        url = "https://docs.oracle.com/javase/%d/docs/api/overview-summary.html"
+        for version in [6, 7, 8]:
+            request = scrapy.Request(url % version, callback=self._parse_css)
+            request.meta["version"] = str(version)
+            if version == 6:
+                request.meta["css"] = "tr.TableRowColor > td > b > a::text"
+            else:
+                request.meta["css"] = "tr.altColor > td > a::text"
+            yield request
+        url = "https://docs.oracle.com/javase/%d/docs/api/module-search-index.zip"
+        for version in [9, 10]:
+            request = scrapy.Request(url % version, callback=self._parse_zip)
+            request.meta["version"] = str(version)
+            yield request
+
+    def _parse_css(self, response):
+        """Parse the response for the index."""
+        library_metadata = [response.meta["version"]]
+        for library_name in response.css(response.meta["css"]).getall():
+            yield {
+                "library_name": library_name,
+                "lang": "java",
+                "library_metadata": library_metadata,
+            }
+
+    def _parse_zip(self, response):
+        """Parse the response for each package."""
+        library_metadata = [response.meta["version"]]
+        content = json.loads(
+            ZipFile(BytesIO(response.body))
+            .read("module-search-index.json")
+            .decode(encoding="utf-8")
+        )
+        for d in content:
+            yield {
+                "library_name": d["l"],
+                "lang": "java",
+                "library_metadata": library_metadata,
+            }

--- a/sourced/ml/mining/spiders/python_stdlib.py
+++ b/sourced/ml/mining/spiders/python_stdlib.py
@@ -1,0 +1,53 @@
+import zlib
+
+import scrapy
+
+
+class PythonStdlibSpider(scrapy.Spider):
+    """Spider for scraping the Python standard libraries."""
+
+    name = "python-stdlib-spider"
+
+    def start_requests(self):
+        """Start making requests."""
+        url = "http://docs.python.org/%.1f/objects.inv"
+        for v in [2.6, 3.0, 3.1]:
+            request = scrapy.Request(url % v, callback=self._parse_old_sphinx)
+            request.meta["version"] = str(v)
+            yield request
+        for v in [2.7, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8]:
+            request = scrapy.Request(url % v, callback=self._parse_new_sphinx)
+            request.meta["version"] = str(v)
+            yield request
+
+    def _parse_old_sphinx(self, response):
+        """Parse the response for old sphinx docs."""
+        content = response.body.decode(encoding="utf-8")
+        library_metadata = [response.meta["version"]]
+        for line in content.splitlines():
+            line = line.split()
+            if line[1] == "mod":
+                yield {
+                    "library_name": line[0],
+                    "lang": "python",
+                    "library_metadata": library_metadata,
+                }
+
+    def _parse_new_sphinx(self, response):
+        """Parse the response for new sphinx docs."""
+        body = response.body
+        for start in range(len(body)):
+            try:
+                content = zlib.decompress(body[start:])
+                break
+            except zlib.error:
+                pass
+        library_metadata = [response.meta["version"]]
+        for line in content.decode(encoding="utf-8").splitlines()[2:]:
+            line = line.split()
+            if line[1] == "py:module":
+                yield {
+                    "library_name": line[0],
+                    "lang": "python",
+                    "library_metadata": library_metadata,
+                }

--- a/sourced/ml/mining/spiders/ruby_stdlib.py
+++ b/sourced/ml/mining/spiders/ruby_stdlib.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import scrapy
+
+
+class RubyStdlibSpider(scrapy.Spider):
+    """Spider for scraping the Ruby standard libraries."""
+
+    name = "ruby-stdlib-spider"
+
+    def start_requests(self):
+        """Start making requests."""
+        url = "https://ruby-doc.org"
+        yield scrapy.Request(url, callback=self._parse_index)
+
+    def _parse_index(self, response):
+        """Parse the response for the index."""
+        root = Path("/")
+        for href in response.css(
+            "ul#stdlib-api-list > li > span > a::attr(href)"
+        ).getall():
+            url = response.url + (root / href / "toc.html").as_posix()
+            yield scrapy.Request(url, callback=self._parse)
+
+    def _parse(self, response):
+        """Parse the response for each package."""
+        version = response.url.split("/")[-2].split("-")[1]
+        library_metadata = [version]
+        for library_name in response.css("a.mature::text").getall():
+            yield {
+                "library_name": library_name,
+                "lang": "ruby",
+                "library_metadata": library_metadata,
+            }

--- a/sourced/ml/mining/utils/__init__.py
+++ b/sourced/ml/mining/utils/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+from sourced.ml.mining.utils.fs import check_remove_filepath, path_with_suffix
+

--- a/sourced/ml/mining/utils/fs.py
+++ b/sourced/ml/mining/utils/fs.py
@@ -1,0 +1,20 @@
+from logging import Logger
+from pathlib import Path
+
+
+def path_with_suffix(path: Path, suffix: str):
+    """Adds a suffix to a path if necessary."""
+    if suffix and not path.suffix == suffix:
+        path = path.with_suffix(suffix)
+    return path
+
+
+def check_remove_filepath(path: Path, log: Logger, force: bool):
+    """Checks the path does not point to a file, if it does will raise an error or remove it."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if not force:
+            log.error("%s already exists, aborting (use -f/--force to overwrite)", path)
+            raise FileExistsError
+        log.warn("%s already exists, overwritten", path)
+        path.unlink()


### PR DESCRIPTION
The code to extract standard lib. I also added a couple util functions. 

- C++: 132 libraries, we get them from the [reference](https://en.cppreference.com/w/cpp/header) which also include the standard C headers and the deprecated headers. We only have to scrape one page with regex so it's quite easy.
- C#: 4253 libraries, we get them from the [microsoft website](https://docs.microsoft.com/en-us/dotnet/api/). This is the most annoying, because we collect the libraries for each API and each version, eg `.NET` Core from version 1 to 3, `.Net` Standard from 1. to 4.8 ... We first get an index then scrape each page.
- Go: we scrape the [doc](https://godoc.org/) to get the standard lib as well as the other packages of the Go Project that are not core (the `golang.org/x/` packages)
- Java: 1047  libraries, we get libraries for versions 6,7,8,9 and 10. For the 3 first we use xpath, but it;s different for version 6, and for the later versions we just get a json. They are taken from this [the oracle website](https://docs.oracle.com/javase)
- JavaScript: nothing to do, no standard lib
- PHP: there is a standard lib but I think you don't import it
- Python: 325 packages, we can get the list from a page the [doc](http://docs.python.org/) and extract it with zlib, includes all versions (could be differentiated by version).
- Ruby: 137 packages, we scrape the [documentation](https://ruby-doc.org/stdlib-2.6.5/) of each version after retrieving it.

It takes about 5min to extract everything, the slowest one being C#. The model is tiny, only about 62KB. I did not do anything fancy but we could improve the mining to associate versions for Ruby, Python, C# and Java with no effort. Go has the backwards compatibility so same, we would only need to be more clever with C++.